### PR TITLE
Add argument name suffix

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function preprocess(func) {
   var argNames = getArgNames(ast)
   var compiledArgs = new Array(argNames.length)
   for(var i=0; i<argNames.length; ++i) {
-    compiledArgs[i] = new CompiledArgument(prefix + "arg" + i, false, false)
+    compiledArgs[i] = new CompiledArgument(prefix + "arg" + i + "_", false, false)
   }
   
   //Create temporary data structure for source rewriting


### PR DESCRIPTION
Otherwise, cwise ends up generating invalid code when there's more than 9 arguments.

Was checking out ndarray-stencil and got this:

``` javascript
arr0[ptr0]=scalar0(
arr1[ptr1],
arr2[ptr2],
arr3[ptr3],
arr4[ptr4],
arr5[ptr5],
arr6[ptr6],
arr7[ptr7],
arr8[ptr8],
arr0[ptr0]0
)
```

Simple fix :)
