### PR TITLE
Fix Node v6 incompatibility, DeprecationWarning: 'GLOBAL' is deprecated, use 'global'

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ function isGlobal(identifier) {
   }
   if(typeof window !== "undefined") {
     return identifier in window
-  } else if(typeof GLOBAL !== "undefined") {
-    return identifier in GLOBAL
+  } else if(typeof global !== "undefined") {
+    return identifier in global
   } else if(typeof self !== "undefined") {
     return identifier in self
   } else {


### PR DESCRIPTION
Node.js v6 deprecated capitalized `GLOBAL` in favor of lowercased `global`, in https://github.com/nodejs/node/pull/1838

Using `GLOBAL` prints a warning to stderr, which breaks wzrd (500 error): https://github.com/maxogden/wzrd/issues/15

This PR updates GLOBAL to global in cwise-parser, fixing the deprecation warning and avoiding the server error