### PR TITLE
Update esprima

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "esprima": "^1.0.3",
+    "esprima": "^2.7.2",
     "uniq": "^1.0.0"
   },
   "devDependencies": {

--- a/test/test.es6
+++ b/test/test.es6
@@ -2,9 +2,9 @@
 
 var parse = require("../index.js")
 
-require("tape")("basic tests", function(t) {
+require("tape")("es6 tests", function(t) {
 
-  var parsed = parse(function(a, b, c) {
+  var parsed = parse((a, b, c) => {
     a += b
     c = Math.cos(b)
   })
@@ -25,17 +25,3 @@ require("tape")("basic tests", function(t) {
 
   t.end()
 })
-
-
-function isArrowFunctionSupported() {
-  try {
-    new Function('() => {}');
-  } catch (err) {
-    return false;
-  }
-  return true;
-}
-
-if (isArrowFunctionSupported()) {
-  require('./test.es6');
-}


### PR DESCRIPTION
This PR updates `esprima`. Since `esprima` v1.0.3, which is the version `cwise-parser` currently uses, there are [many changes](https://github.com/jquery/esprima/blob/master/ChangeLog) in `esprima`, especially for es6 support.

I briefly checked if there is any breaking change between `esprima` v1 and v2 but couldn't find anything.

This PR contains a basic test suite for es6 arrow function, and `cwise` was tested with this update in [this repo](https://github.com/pawsong/cwise).
