### PR TITLE
increase counter before calling parse

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,11 +44,12 @@ function getArgNames(ast) {
 }
 
 function preprocess(func) {
+  PREFIX_COUNTER++;
+  //Compute new prefix
+  var prefix = "_inline_" + PREFIX_COUNTER + "_"
+  
   var src = ["(", func, ")()"].join("")
   var ast = esprima.parse(src, { range: true })
-  
-  //Compute new prefix
-  var prefix = "_inline_" + (PREFIX_COUNTER++) + "_"
   
   //Parse out arguments
   var argNames = getArgNames(ast)


### PR DESCRIPTION
We sometimes get different `inline` numbers when building `plotly.js` for `Chart Studio` nodes.
cc: https://github.com/plotly/streambed/issues/13816
![inline-diff](https://user-images.githubusercontent.com/33888540/78158222-f9f26d00-740e-11ea-82cb-04e915d8bf3b.png).

This PR attempts to address this issue by increasing the global counter before calling time-consuming parse function.

@mikolalysenko 